### PR TITLE
Added ValidOutputTypesRule

### DIFF
--- a/core/rule.go
+++ b/core/rule.go
@@ -309,3 +309,30 @@ func (rule *RowRule) Validate(tx *Transaction, linkedOutputs map[string]Output,
 
 	return nil
 }
+
+// --------------------------------
+// ValidOutputTypesRule implementation
+//
+// Used to check whether transaction only has certain output types
+// --------------------------------
+
+type ValidOutputTypesRule struct {
+	validTypes map[OutputType]bool // map is used as a set here
+}
+
+func (rule *ValidOutputTypesRule) RequiredOutputIds(tx *Transaction) [][]byte {
+	return [][]byte{}
+}
+
+func (rule *ValidOutputTypesRule) Validate(tx *Transaction, linkedOutputs map[string]Output,
+	spentInputs map[string][]Input) error {
+
+	for _, output := range tx.Outputs {
+		if _, ok := rule.validTypes[output.Type()]; !ok {
+			return errors.New(fmt.Sprintf("Invalid output type: %d\nExpected: %v\n",
+				output.Type(), rule.validTypes))
+		}
+	}
+
+	return nil
+}

--- a/core/rule_test.go
+++ b/core/rule_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidOutputTypesRule(t *testing.T) {
+	tx := &Transaction{
+		Outputs: []Output{
+			&TableExistsOutput{},
+			&ColAllowedOutput{},
+		},
+	}
+
+	rule := &ValidOutputTypesRule{
+		validTypes: map[OutputType]bool{
+			OUTPUT_TYPE_TABLE_EXISTS: true,
+			OUTPUT_TYPE_COL_ALLOWED:  true,
+		},
+	}
+
+	assert.Nil(t, rule.Validate(tx, nil, nil))
+}
+
+func TestValidOutputTypesRuleInvalid(t *testing.T) {
+	tx := &Transaction{
+		Outputs: []Output{
+			&TableExistsOutput{},
+			&ColAllowedOutput{},
+		},
+	}
+
+	rule := &ValidOutputTypesRule{
+		validTypes: map[OutputType]bool{
+			OUTPUT_TYPE_TABLE_EXISTS: true,
+		},
+	}
+
+	assert.IsType(t, errors.New(""), rule.Validate(tx, nil, nil))
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -36,16 +36,37 @@ type Transaction struct {
 var rulesets = map[TransactionType][]Rule{
 	TRANSACTION_TYPE_CREATE_TABLE: []Rule{
 		&TableMissingRule{},
+		&ValidOutputTypesRule{validTypes: map[OutputType]bool{
+			OUTPUT_TYPE_TABLE_EXISTS:     true,
+			OUTPUT_TYPE_COL_ALLOWED:      true,
+			OUTPUT_TYPE_ALL_COLS_ALLOWED: true,
+			OUTPUT_TYPE_ALL_ADMINS:       true,
+			OUTPUT_TYPE_ADMIN:            true,
+			OUTPUT_TYPE_ALL_WRITERS:      true,
+			OUTPUT_TYPE_WRITER:           true,
+		}},
 	},
 	TRANSACTION_TYPE_UPDATE_TABLE: []Rule{
 		&TableExistsRule{},
 		&AdminRule{},
+		&ValidOutputTypesRule{validTypes: map[OutputType]bool{
+			OUTPUT_TYPE_COL_ALLOWED:      true,
+			OUTPUT_TYPE_ALL_COLS_ALLOWED: true,
+			OUTPUT_TYPE_ALL_ADMINS:       true,
+			OUTPUT_TYPE_ADMIN:            true,
+			OUTPUT_TYPE_ALL_WRITERS:      true,
+			OUTPUT_TYPE_WRITER:           true,
+		}},
 	},
 	TRANSACTION_TYPE_PUT_CELLS: []Rule{
 		&TableExistsRule{},
 		&ColsAllowedRule{},
 		&WriterRule{},
 		&RowRule{},
+		&ValidOutputTypesRule{validTypes: map[OutputType]bool{
+			OUTPUT_TYPE_ALL_ROW_WRITERS: true,
+			OUTPUT_TYPE_ROW_WRITER:      true,
+		}},
 	},
 }
 


### PR DESCRIPTION
This rule ensures that all of the outputs of a particular transaction are within some whitelisted set of output types.